### PR TITLE
Add calendar and realtime editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Documentation
+
+- [Architecture Guide](docs/ArchitectureGuide.md)

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="calendar"
+        options={{
+          title: 'Calendar',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="calendar" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,0 +1,39 @@
+import { Calendar } from 'react-native-calendars';
+import { StyleSheet } from 'react-native';
+import { useState } from 'react';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function CalendarScreen() {
+  const [markedDates, setMarkedDates] = useState<{[date: string]: any}>({});
+
+  const handleDayPress = (day: any) => {
+    const dateStr = day.dateString;
+    setMarkedDates((prev) => ({
+      ...prev,
+      [dateStr]: {
+        selected: true,
+        marked: true,
+        selectedColor: '#007AFF',
+      },
+    }));
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <Calendar
+        onDayPress={handleDayPress}
+        markedDates={markedDates}
+        theme={{
+          selectedDayBackgroundColor: '#007AFF',
+          todayTextColor: '#007AFF',
+        }}
+      />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/docs/ArchitectureGuide.md
+++ b/docs/ArchitectureGuide.md
@@ -1,0 +1,63 @@
+# React Native Expo Fitness App Architecture Guide
+
+This guide outlines a recommended technical architecture for a production-ready fitness application built with **React Native** and **Expo**. The approach focuses on offline capability, real-time sync, multi-AI integration, and progressive authentication.
+
+## Overview
+
+The architecture combines the following technologies:
+
+- **TanStack Query** for server state management
+- **Zustand** for local client state
+- **WatermelonDB** to provide offline-first storage with sync capabilities
+- **Supabase** to sync data in real time via subscriptions
+- A **multi-AI provider layer** that supports OpenAI, Google Gemini and Perplexity APIs
+
+The following sections summarise key P0–P2 features and implementation details.
+
+## P0 Features: Calendar & Real-Time Editing
+
+### Calendar Integration
+
+Use `react-native-calendars` for displaying a rich calendar with marked workout days and event handling. Cross-platform event creation is implemented with `react-native-calendar-events` so workouts can appear in native device calendars.
+
+### Real-Time Exercise Editing
+
+Exercise edits stream from the backend using **Server‑Sent Events**. Optimistic updates are applied in WatermelonDB and later reconciled with server data. This approach allows multiple clients to update a workout concurrently while remaining responsive offline.
+
+## P1 Feature: Progressive Authentication
+
+Start users anonymously and progressively upgrade to a full account. Support biometric authentication and optional linking to Apple Health, Google Fit or Fitbit accounts. This staged approach reduces friction for first‑time users.
+
+## P2 Feature: Health Platform Integrations
+
+Implement adapters for Apple HealthKit and Google Fit. Synchronise workouts, heart rate and step data. Expand to other platforms as demand grows.
+
+## Multi-AI System Infrastructure
+
+A router directs AI requests to the most cost‑effective model (e.g. Gemini Flash or GPT‑3.5) while reserving premium models for complex tasks. Responses are cached to reduce repeated API calls. Providers share a common interface so new services can be added easily.
+
+## State Management
+
+Combine **TanStack Query** for server data with **Zustand** for ephemeral UI state. Persist vital workout data locally using the `persist` middleware so sessions resume reliably even when offline.
+
+## Database & Offline Strategy
+
+WatermelonDB stores workouts and exercises locally and tracks sync status. Conflict resolution prefers completed workouts and merges performance metrics intelligently. The Supabase schema includes version columns for optimistic concurrency control.
+
+## Security & Compliance
+
+Health data is encrypted with AES before storing on device. GDPR/CCPA compliance is achieved with export and delete helpers that cascade changes across connected services.
+
+## Performance Considerations
+
+- Use `FlashList` from Shopify for large workout history lists
+- Run workout tracking logic in a background service to keep timers accurate
+
+## Deployment
+
+EAS Build is recommended for continuous integration. Development, preview and production profiles can use different environment variables and distribution strategies.
+
+---
+
+This architecture provides a scalable and secure starting point for building a modern fitness application that leverages AI while remaining performant on mobile devices.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/ngrok": "^4.1.3",
         "@expo/vector-icons": "^14.1.0",
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -29,6 +30,8 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.3",
+        "react-native-calendar-events": "^2.2.0",
+        "react-native-calendars": "^1.1312.1",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
@@ -2696,6 +2699,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
@@ -8289,6 +8298,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -8878,6 +8893,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -9659,7 +9684,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9669,8 +9693,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -9910,6 +9933,47 @@
         }
       }
     },
+    "node_modules/react-native-calendar-events": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-calendar-events/-/react-native-calendar-events-2.2.0.tgz",
+      "integrity": "sha512-tNUbhT6Ief0JM4OQzQAaz1ri0+MCcAoHptBcEXCz2g7q3A05pg62PR2Dio4F9t2fCAD7Y2+QggdY1ycAsF3Tsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
+      }
+    },
+    "node_modules/react-native-calendars": {
+      "version": "1.1312.1",
+      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1312.1.tgz",
+      "integrity": "sha512-295577LyDmLF53wURndNFly6SFQRpKR4d+fzGiIUs1FzdT1JK7uydtCUqm4++eKDuwhsz2mXJkszmTi6etsTdw==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.1",
+        "lodash": "^4.17.15",
+        "memoize-one": "^5.2.1",
+        "prop-types": "^15.5.10",
+        "react-native-safe-area-context": "4.5.0",
+        "react-native-swipe-gestures": "^1.0.5",
+        "recyclerlistview": "^4.0.0",
+        "xdate": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "moment": "^2.29.4"
+      }
+    },
+    "node_modules/react-native-calendars/node_modules/react-native-safe-area-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
+      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
@@ -9988,6 +10052,12 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-swipe-gestures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
+      "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
+      "license": "MIT"
     },
     "node_modules/react-native-web": {
       "version": "0.20.0",
@@ -10111,6 +10181,21 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recyclerlistview": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.3.tgz",
+      "integrity": "sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "4.0.8",
+        "prop-types": "15.8.1",
+        "ts-object-utils": "0.0.5"
+      },
+      "peerDependencies": {
+        "react": ">= 15.2.1",
+        "react-native": ">= 0.30.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11550,6 +11635,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-object-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
+      "license": "ISC"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -12250,6 +12341,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/xdate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.3.tgz",
+      "integrity": "sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==",
+      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/xml2js": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@expo/ngrok": "^4.1.3",
     "@expo/vector-icons": "^14.1.0",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
@@ -32,6 +33,8 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.3",
+    "react-native-calendar-events": "^2.2.0",
+    "react-native-calendars": "^1.1312.1",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",

--- a/services/ExerciseRealtimeManager.ts
+++ b/services/ExerciseRealtimeManager.ts
@@ -1,0 +1,39 @@
+import { EventSourceMessage, fetchEventSource } from '@microsoft/fetch-event-source';
+
+export type ExerciseUpdateCallback = (data: any) => void;
+
+export class ExerciseRealtimeManager {
+  private eventSource: AbortController | null = null;
+  private subscriptions = new Map<string, ExerciseUpdateCallback>();
+
+  subscribe(workoutId: string, callback: ExerciseUpdateCallback) {
+    this.subscriptions.set(workoutId, callback);
+    if (!this.eventSource) {
+      this.startEventSource(workoutId);
+    }
+  }
+
+  private async startEventSource(workoutId: string) {
+    this.eventSource = new AbortController();
+    await fetchEventSource(`${process.env.API_BASE_URL}/workouts/${workoutId}/stream`, {
+      signal: this.eventSource.signal,
+      onmessage: (msg: EventSourceMessage) => {
+        const data = JSON.parse(msg.data);
+        const cb = this.subscriptions.get(workoutId);
+        if (cb) cb(data);
+      },
+      onclose: () => {
+        this.eventSource = null;
+      },
+    });
+  }
+
+  async updateExercise(workoutId: string, exerciseId: string, updates: any) {
+    // Optimistic update could happen here via state management
+    await fetch(`${process.env.API_BASE_URL}/workouts/${workoutId}/exercises/${exerciseId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    });
+  }
+}

--- a/services/WorkoutScheduler.ts
+++ b/services/WorkoutScheduler.ts
@@ -1,0 +1,27 @@
+import RNCalendarEvents from 'react-native-calendar-events';
+
+export type WorkoutEvent = {
+  name: string;
+  scheduledAt: Date;
+  duration: number; // minutes
+  location?: string;
+  description?: string;
+  targetCalories?: number;
+};
+
+export const WorkoutScheduler = {
+  async schedule(workout: WorkoutEvent) {
+    const perm = await RNCalendarEvents.checkPermissions();
+    if (perm !== 'authorized') {
+      await RNCalendarEvents.requestPermissions();
+    }
+
+    return RNCalendarEvents.saveEvent(workout.name, {
+      startDate: workout.scheduledAt.toISOString(),
+      endDate: new Date(workout.scheduledAt.getTime() + workout.duration * 60000).toISOString(),
+      location: workout.location ?? 'Gym',
+      notes: `${workout.description ?? ''}\nCalories target: ${workout.targetCalories ?? ''}`,
+      alarms: [{ date: -15 }],
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- add calendar screen using `react-native-calendars`
- integrate cross-platform workout scheduling helper
- support real-time exercise edits via Server-Sent Events
- enable calendar tab in the navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ecb03a0c8832bb1dc42b007dde0ae